### PR TITLE
Set up Travis to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+cache: pip
+install:
+  - pip install -r requirements.txt
+script:
+  - python -m unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
-python:
-  - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
 cache: pip
 install:
   - pip install -r requirements.txt

--- a/cassandra/test/test_add_cap.py
+++ b/cassandra/test/test_add_cap.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+Test that components add capabilities as expected, and errors when adding a
+duplicate or fetching a non-existing capability.
+"""
+
+from cassandra.components import DummyComponent, CapabilityNotFound
+import unittest
+
+
+class TestCapabilities(unittest.TestCase):
+    def setUp(self):
+        """Defines the DummyComponents that interact with each other."""
+        capability_table = {}
+
+        self.d1 = DummyComponent(capability_table, 'Alice')
+        self.d2 = DummyComponent(capability_table, 'Bob')
+
+    def testAddCap(self):
+        """Test that adding a capability puts it in the capability table"""
+        # The name of the component should be in there from initialization
+        self.assertIn('Alice', self.d1.cap_tbl)
+        self.d1.addcapability('NewCapability')
+        self.assertIn('NewCapability', self.d1.cap_tbl)
+
+    def testAddCapErr(self):
+        """Test that adding a duplicate capability errors"""
+        self.assertRaises(RuntimeError, self.d1.addcapability, 'Alice')
+
+    def testGetNonExistErr(self):
+        """Test that fetching a non-existing capability errors"""
+        self.assertRaises(CapabilityNotFound, self.d1.fetch, 'NotACapability')
+
+    def testAddOtherComponentCapErr(self):
+        """Test to ensure we can't add results to another component's capability."""
+        data = 'ResultsFromAlice'
+        self.d1.addresults('Alice', data)
+        self.assertEqual(self.d1.results['Alice'], data)
+        self.assertRaises(RuntimeError, self.d1.addresults, 'Bob', data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cassandra/test/test_blocking.py
+++ b/cassandra/test/test_blocking.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+"""
+Test that components block when they are supposed to and get released when they
+are supposed to.
+"""
+
+from cassandra.components import *
+import unittest
+
+
+class TestBlocking(unittest.TestCase):
+    def setUp(self):
+        """Defines the DummyComponents that interact with each other."""
+        capability_table = {}
+
+        self.d1 = DummyComponent(capability_table, 'Alice')
+        self.d2 = DummyComponent(capability_table, 'Bob')
+        self.d3 = DummyComponent(capability_table, 'Carol')
+
+        self.component_list = [self.d1, self.d2, self.d3]
+        self.names = [c.name for c in self.component_list]
+
+    def testDelay(self):
+        """Test that the time delay is working as expected."""
+        self.d1.addparam('capability_reqs', ['Carol'])
+        self.d1.addparam('request_delays', [1000])
+        self.d1.addparam('finish_delay', 1000)
+
+        self.d2.addparam('capability_reqs', ['Carol'])
+        self.d2.addparam('request_delays', [0])
+        self.d2.addparam('finish_delay', 1000)
+
+        self.d3.addparam('capability_reqs', [])
+        self.d3.addparam('request_delays', [])
+        self.d3.addparam('finish_delay', 1000)
+
+        self.runComponents()
+        self.confirmSuccess()
+
+        # The last time in the results' times list is the completion time
+        finish_times = [c.report_test_results()[-1][0] for c in self.component_list]
+
+        # Round to the nearest second for comparison
+        finish_seconds = [round(ft) for ft in finish_times]
+
+        self.assertEqual(finish_seconds[0], 2)  # 1s before request + 1s finish
+        self.assertEqual(finish_seconds[1], 2)  # 1s wait + 1s finish
+        self.assertEqual(finish_seconds[2], 1)  # 1s finish
+
+    def testBlocking(self):
+        """Test that a component is blocked while waiting for another."""
+        finish_delay = 100
+
+        # Make each component depend on all of the components in front of it
+        for i, c in enumerate(self.component_list):
+            c.addparam('capability_reqs', self.names[i + 1:])
+            c.addparam('request_delays', [0 for _ in self.names])
+            c.addparam('finish_delay', finish_delay)
+
+        self.runComponents()
+        self.confirmSuccess()
+
+        # Calculate the ms it took to ran the first component
+        d1_time = self.d1.report_test_results()[-1][0]
+        d1_ms = round(d1_time, 1) * 1000
+
+        # Should have had to wait for each component to finish; the only delay
+        # in this test is the finish delay
+        self.assertEqual(d1_ms, finish_delay * len(self.component_list))
+
+    def confirmSuccess(self):
+        """Ensure each component finished successfully."""
+        for component in self.component_list:
+            self.assertEqual(component.status, 1)
+
+    def runComponents(self):
+        """Run each component."""
+        threads = []
+
+        for component in self.component_list:
+            threads.append(component.run())
+
+        # Wait for all threads to complete before printing end message.
+        for thread in threads:
+            thread.join()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     long_description=readme(),
     install_requires=get_requirements(),
     classifiers=[
-        "Programming Language :: Python :: 3"
+        "Programming Language :: Python :: 3.6"
+        "Programming Language :: Python :: 3.7"
     ]
 )


### PR DESCRIPTION
Tests can be run with `python -m unittest unittest`. This recurses through all lower directories looking for `test*.py` modules (by default), then running them.