### PR TITLE
Create end-to-end test using cassandra_main

### DIFF
--- a/cassandra/cassandra_main.py
+++ b/cassandra/cassandra_main.py
@@ -1,7 +1,7 @@
-#!/bin/env python
+#!/usr/bin/env python3
 """Cassandra model coupling framework
 
-  usage:  cassandra.py <configfile>
+  usage:  cassandra_main.py <configfile>
 
   This program will run the cassandra model coupling system using the
   configuration details from the configuration file supplied on the
@@ -13,11 +13,17 @@
 import sys
 import re
 import threading
+import argparse
 
 
-def config_parse(cfgfile_name):
+def config_parse(argvals):
     """Parse the configuration file."""
 
+    if argvals.mp:
+        raise NotImplementedError('Multiprocessing mode is not yet implemented.')
+    
+    cfgfile_name = argvals.ctlfile
+    
     # initialize the structures that will receive the data we are
     # parsing from the file
     capability_table = {}
@@ -91,8 +97,14 @@ def config_parse(cfgfile_name):
 if __name__ == "__main__":
     from cassandra.components import *
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mp', action='store_true', default=False, help='Use multiprocessing.')
+    parser.add_argument('ctlfile', help='Name of the configuration file for the calculation.')
+
+    argvals = parser.parse_args()
+    
     try:
-        (component_list, cap_table) = config_parse(sys.argv[1])
+        (component_list, cap_table) = config_parse(argvals)
     except IndexError:
         print(__doc__)
         sys.exit(0)

--- a/cassandra/test/test_add_cap.py
+++ b/cassandra/test/test_add_cap.py
@@ -13,8 +13,15 @@ class TestCapabilities(unittest.TestCase):
         """Defines the DummyComponents that interact with each other."""
         capability_table = {}
 
-        self.d1 = DummyComponent(capability_table, 'Alice')
-        self.d2 = DummyComponent(capability_table, 'Bob')
+        self.d1 = DummyComponent(capability_table)
+        self.d1.addparam('name','Alice')
+        self.d1.addparam('finish_delay', '1000')
+        self.d2 = DummyComponent(capability_table)
+        self.d2.addparam('name', 'Bob')
+        self.d2.addparam('finish_delay', '1000')
+
+        self.d1.finalize_parsing()
+        self.d2.finalize_parsing()
 
     def testAddCap(self):
         """Test that adding a capability puts it in the capability table"""

--- a/cassandra/test/test_blocking.py
+++ b/cassandra/test/test_blocking.py
@@ -13,26 +13,29 @@ class TestBlocking(unittest.TestCase):
         """Defines the DummyComponents that interact with each other."""
         capability_table = {}
 
-        self.d1 = DummyComponent(capability_table, 'Alice')
-        self.d2 = DummyComponent(capability_table, 'Bob')
-        self.d3 = DummyComponent(capability_table, 'Carol')
+        self.d1 = DummyComponent(capability_table)
+        self.d1.addparam('name', 'Alice')
+        self.d2 = DummyComponent(capability_table)
+        self.d2.addparam('name', 'Bob')
+        self.d3 = DummyComponent(capability_table)
+        self.d3.addparam('name', 'Carol')
 
         self.component_list = [self.d1, self.d2, self.d3]
-        self.names = [c.name for c in self.component_list]
+        self.names = [c.params['name'] for c in self.component_list]
 
     def testDelay(self):
         """Test that the time delay is working as expected."""
-        self.d1.addparam('capability_reqs', ['Carol'])
-        self.d1.addparam('request_delays', [1000])
-        self.d1.addparam('finish_delay', 1000)
+        self.d1.addparam('capability_reqs', 'Carol')
+        self.d1.addparam('request_delays', '1000')
+        self.d1.addparam('finish_delay', '1000')
 
-        self.d2.addparam('capability_reqs', ['Carol'])
-        self.d2.addparam('request_delays', [0])
-        self.d2.addparam('finish_delay', 1000)
+        self.d2.addparam('capability_reqs', 'Carol')
+        self.d2.addparam('request_delays', '0')
+        self.d2.addparam('finish_delay', '1000')
 
-        self.d3.addparam('capability_reqs', [])
-        self.d3.addparam('request_delays', [])
-        self.d3.addparam('finish_delay', 1000)
+        self.d3.addparam('capability_reqs', '')
+        self.d3.addparam('request_delays', '')
+        self.d3.addparam('finish_delay', '1000')
 
         self.runComponents()
         self.confirmSuccess()
@@ -53,8 +56,9 @@ class TestBlocking(unittest.TestCase):
 
         # Make each component depend on all of the components in front of it
         for i, c in enumerate(self.component_list):
-            c.addparam('capability_reqs', self.names[i + 1:])
-            c.addparam('request_delays', [0 for _ in self.names])
+            deps = self.names[i+1:]
+            c.addparam('capability_reqs', ','.join(deps))
+            c.addparam('request_delays', ','.join(['0'] * len(deps)))
             c.addparam('finish_delay', finish_delay)
 
         self.runComponents()
@@ -77,6 +81,9 @@ class TestBlocking(unittest.TestCase):
         """Run each component."""
         threads = []
 
+        for comp in self.component_list:
+            comp.finalize_parsing() 
+        
         for component in self.component_list:
             threads.append(component.run())
 

--- a/example.cfg
+++ b/example.cfg
@@ -4,35 +4,25 @@ DBXMLlib = /people/link593/lib
 inputdir = ./input-data
 rgnconfig = rgn32
 
-[HydroComponent]
-workdir = ../gcam-hydro
-inputdir = /pic/scratch/rpl/CMIP5_preprocessed
-outputdir = output/cmip5
-init-storage-file = ../gcam-hydro/inputs/initstorage.mat
-clobber = False
-logfile = ../gcam-hydro/logs/example-hydro-log.txt
-gcm = CCSM4
-scenario = rcp60
-runid = r1i1p1_200601_210012
+[DummyComponent]
+name = Alice
+finish_delay = 3000
 
-[WaterDisaggregationComponent]
-workdir = ../gcam-hydro
-inputdir = ./input-data
-clobber = False
-logfile = ../gcam-hydro/logs/example-disag-log.txt
-dbxml = /people/link593/wrk/ifam/gcam-test-data/gcam-ifam-32rgn/database_basexdb-new
-tempdir = output/example-tmp
-outputdir = output/example-output
-scenario = rcp60
-water-transfer = False
-transfer-file = /lustre/data/rpl/GCAMhydro/inputs/water-transfer.csv
+[DummyComponent]
+name = Bob
+capability_reqs = Alice
+request_delays = 1000
+finish_delay = 100
 
-[HistoricalHydroComponent]
-workdir = ../gcam-hydro
-inputdir = /pic/scratch/rpl/CMIP5_preprocessed
-outputdir = output/cmip5
-clobber = False
-runid = r1i1p1_195001_200512 
-gcm = CCSM4
-logfile = ../gcam-hydro/logs/example-hist-log.txt
+[DummyComponent]
+name = Chris
+capability_reqs = Alice
+request_delays = 4000
+finish_delay = 1000
+
+[DummyComponent]
+name = Dana
+capability_reqs = Bob, Chris
+request_delays = 1000, 500
+finish_delay = 100
 


### PR DESCRIPTION
You can now run `cassandra_main.py example.cfg` to demonstrate a set
of 4 dummy components.  We will need this in order to test the multiprocessing
version of the code.