### PR TITLE
Ensure that MPI_ABORT is called when a component fails in MP mode.

### DIFF
--- a/cassandra/cassandra_main.py
+++ b/cassandra/cassandra_main.py
@@ -113,9 +113,11 @@ if __name__ == "__main__":
 
     try:
         status = main(argvals)
-    except:
+    except Exception as err:
         if argvals.mp:
             from mpi4py import MPI
+            from logging import exception
+            exception('Fatal error:  calling MPI_Abort.')
             MPI.COMM_WORLD.Abort()
         raise
 

--- a/cassandra/cassandra_main.py
+++ b/cassandra/cassandra_main.py
@@ -52,15 +52,7 @@ def bootstrap_sp(cfgfile_name):
 # end of bootstrap_sp
 
 
-if __name__ == "__main__":
-    from cassandra.components import *
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--mp', action='store_true', default=False, help='Use multiprocessing.')
-    parser.add_argument('ctlfile', help='Name of the configuration file for the calculation.')
-
-    argvals = parser.parse_args()
-
+def main(argvals):
     if argvals.mp:
         # See notes in mp.py about side effects of importing that module.
         from cassandra.mp import bootstrap_mp, finalize
@@ -108,3 +100,22 @@ if __name__ == "__main__":
         print(f'\n****************{fail} components failed.')
 
     print("\nFIN.")
+
+    return fail
+    
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mp', action='store_true', default=False, help='Use multiprocessing.')
+    parser.add_argument('ctlfile', help='Name of the configuration file for the calculation.')
+
+    argvals = parser.parse_args()
+
+    try:
+        status = main(argvals)
+    except:
+        if argvals.mp:
+            from mpi4py import MPI
+            MPI.COMM_WORLD.Abort()
+        raise
+

--- a/cassandra/cassandra_main.py
+++ b/cassandra/cassandra_main.py
@@ -82,29 +82,30 @@ def main(argvals):
     for thread in component_threads:
         thread.join()
 
-    # Check to see if any of the components failed
-    fail = 0
+    # Check to see if any of the components failed, and that the RAB
+    # is still running
+    nfail = 0
     for component in component_list:
-        if component.status != 1:
+        if component.status != 1 or (type(component).__name__ == 'RAB' and component.status != 0):
             from logging import error
             error(f'Component {str(component.__class__)} returned failure status\n')
-            fail += 1
+            nfail += 1
 
-    if fail == 0:
+    if nfail == 0:
         print('\n****************All components completed successfully.')
     else:
-        print(f'\n****************{fail} components failed.')
-        raise RuntimeError(f'{fail} components failed.') 
+        print(f'\n****************{nfail} components failed.')
+        raise RuntimeError(f'{nfail} components failed.')
 
     # If this is a multiprocessing calculation, then we need to
     # perform the finalization procedure
     if argvals.mp:
-        finalize(component_list[0], threads[0]) 
-        
+        finalize(component_list[0], threads[0])
+
     print("\nFIN.")
 
-    return fail
-    
+    return nfail
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -134,4 +135,3 @@ if __name__ == "__main__":
             MPI.COMM_WORLD.Abort()
 
     # end of main block.
-

--- a/cassandra/cassandra_main.py
+++ b/cassandra/cassandra_main.py
@@ -83,13 +83,28 @@ def main(argvals):
         thread.join()
 
     # Check to see if any of the components failed, and that the RAB
-    # is still running
+    # is still running.  Once again take advantage of the fact that
+    # if the RAB is present, it is always the first in the list.
     nfail = 0
-    for component in component_list:
-        if component.status != 1 or (type(component).__name__ == 'RAB' and component.status != 0):
+    
+    if argvals.mp:
+        reg_comps = component_list[1:]
+        rab_comp = component_list[0]
+    else:
+        reg_comps = component_list
+        rab_comp = None
+        
+    for component in reg_comps:
+        if component.status != 1:
             from logging import error
             error(f'Component {str(component.__class__)} returned failure status\n')
             nfail += 1
+            
+    if rab_comp is not None and rab_comp.status != 0:
+        from logging import error
+        error('RAB has crashed or is otherwise not running.')
+        nfail += 1
+        
 
     if nfail == 0:
         print('\n****************All components completed successfully.')

--- a/cassandra/cassandra_main.py
+++ b/cassandra/cassandra_main.py
@@ -139,14 +139,5 @@ if __name__ == "__main__":
             exception('Fatal error:  calling MPI_Abort.')
             MPI.COMM_WORLD.Abort()
         raise
-    finally:
-        # If the exception happened in a thread, it won't land in the
-        # exception block above.  Assume that if any components
-        # reported failure, then we need to abort the entire group.
-        if argvals.mp and status > 0:
-            from mpi4py import MPI
-            from logging import critical
-            critical(f'{status} components failed.  Calling MPI_Abort.')
-            MPI.COMM_WORLD.Abort()
 
     # end of main block.

--- a/cassandra/components.py
+++ b/cassandra/components.py
@@ -802,6 +802,9 @@ class DummyComponent(ComponentBase):
     capability_reqs - list of the capabilities this component requests
      request_delays - list of time delays (ms) before each request is made
        finish_delay - delay (ms) before the component finalizes and exports
+             except - Throw an exception with the parameter value just before
+                      the component would have exited (this is used for testing 
+                      error handling).
     """
 
     def __init__(self, cap_tbl):
@@ -871,6 +874,10 @@ class DummyComponent(ComponentBase):
         self.addresults(self.name, data)
 
         data.append((time() - st, f'Done {self.name}'))
+
+        # If configuration calls for us to fail, do so.
+        if 'except' in self.params:
+            raise RuntimeError(self.params['except'])
 
         return 0
 

--- a/cassandra/components.py
+++ b/cassandra/components.py
@@ -197,19 +197,26 @@ class ComponentBase(object):
         # eventually try to implement co-simulations.
         with self.condition:
             try:
+                import logging
+                logging.info(f'starting {self.__class__}')
                 rv = self.run_component()
                 if not rv == 0:
                     # possibly add some other error handling here.
-                    raise RuntimeError(f"{self.__class__}:  run_component returned error code {str(rv)}")
+                    msg = f"{self.__class__}:  run_component returned error code {str(rv)}"
+                    logging.error(msg)
+                    raise RuntimeError(msg)
                 else:
-                    stdout.write(f"{self.__class__}: finished successfully.\n")
+                    logging.info(f"{self.__class__}: finished successfully.\n")
 
                 self.status = 1                  # set success condition
             except:
                 self.status = 2                  # set error condition
+                logging.exception(f'Exception in component {str(self.__class__)}.')
                 raise
             finally:
                 self.condition.notify_all()      # release any waiting threads
+
+            logging.info(f'completed {self.__class__}')
         # end of with block:  lock on condition var released.
 
     def fetch(self, capability):
@@ -877,7 +884,10 @@ class DummyComponent(ComponentBase):
 
         # If configuration calls for us to fail, do so.
         if 'except' in self.params:
-            raise RuntimeError(self.params['except'])
+            from logging import critical
+            msg = self.params['except']
+            critical(msg)
+            raise RuntimeError(msg)
 
         return 0
 

--- a/cassandra/rab.py
+++ b/cassandra/rab.py
@@ -29,8 +29,8 @@ class RAB(object):
     def __init__(self, cap_tbl, comm=MPI.COMM_WORLD):
         self.cap_tbl = cap_tbl
         self.comm = comm
-        self.rank = comm.Get_rank()
-        self.status = 0         # status indicator follows ComponentBase convention
+        self.rank = comm.Get_rank() 
+        self.status = 1         # Always show RAB status as successful
         self.terminate = False   # sentinel indicating when it's time for the RAB to exit
         self.remote_caps = {}   # Table of remote capabilities
         self.requests_outstanding = {} # Table of requests in process 
@@ -167,8 +167,6 @@ class RAB(object):
 
                 sleep(RAB_LOOP_SLEEP)
 
-        # Record our status as successful
-        self.status = 1
         logging.debug(f'self.comm.Get_rank(): listen exiting')
         return 0
     

--- a/extras/exception.cfg
+++ b/extras/exception.cfg
@@ -1,0 +1,28 @@
+[Global]
+ModelInterface = /people/link593/wrk/ModelInterface-baseX/ModelInterface.jar
+DBXMLlib = /people/link593/lib
+inputdir = ./input-data
+rgnconfig = rgn32
+
+[DummyComponent.1]
+name = Alice
+finish_delay = 3000
+
+[DummyComponent.2]
+name = Bob
+capability_reqs = Alice
+request_delays = 1000
+finish_delay = 100
+
+[DummyComponent.3]
+name = Chris
+capability_reqs = Alice
+request_delays = 4000
+finish_delay = 1000
+except = Nobody expects the Spanish Inquisition!
+
+[DummyComponent.4]
+name = Dana
+capability_reqs = Bob, Chris
+request_delays = 1000, 500
+finish_delay = 100

--- a/extras/mptest.zsh
+++ b/extras/mptest.zsh
@@ -11,10 +11,9 @@
 ## python.  Cassandra has been tested with OpenMPI 3.1.0 and
 ## python/anaconda 3.6.4
 
-## This batch script should be submitted from the top level of the
-## cassandra repository (one level up from the directory that the
-## script lives in).
+## This batch script should be submitted from the extras subdir of the
+## cassandra repository.
 
 echo "nodes: $SLURM_JOB_NODELIST"
 
-mpirun -np 4 ./cassandra/cassandra_main.py --mp ./extras/example.cfg
+mpirun -np 4  ../cassandra/cassandra_main.py --mp ./example.cfg


### PR DESCRIPTION
Crikey, what a mess.  Between the devious ways that exceptions are processed in multi-threaded code and some subtle race conditions, it took several tries to get this one right.  I've tried to clean up all the cruft from the debugging process, but we will want to inspect this one carefully on review, as it's entirely possible that there is some junk left in from a failed attempt.

Fixes #37 