### PR TITLE
Grand Experiment fixes

### DIFF
--- a/cassandra/mp.py
+++ b/cassandra/mp.py
@@ -164,7 +164,8 @@ def distribute_assignments_supervisor(args):
     except ValueError as e:
         raise RuntimeError("Config file must have a '[Global]' section") from e
 
-    section_weights = [config[s].get('mp.weight', 1.0) for s in section_names]
+    section_weights = [float(config[s].get('mp.weight', 1.0)) for s in section_names]
+    logging.debug(f'section_weights: {section_weights}')
     name_weight = zip(section_names, section_weights)
     section_names = [s[0] for s in sorted(name_weight, key=lambda x:x[1], reverse=True)]
 


### PR DESCRIPTION
- Parameter for the Xanthos output directory (to prevent overwriting for large runs)
- Reduce fldgen array type from float64 to float32 to keep size smaller
- 2 bugfixes

It would be better to, at some point, allow any Xanthos parameter to be passed on from the cassandra config.

We should address the issue discovered by having large arrays being passed from one node to another. The issue is that numpy arrays have an attribute `nbytes` which is an integer describing how many bytes are in the array. When `nbytes` is greater than a C int (2**31 - 1), MPI errors, as it cannot convert the number.